### PR TITLE
Support for mutiple ghq roots

### DIFF
--- a/functions/peco_select_ghq_repository.fish
+++ b/functions/peco_select_ghq_repository.fish
@@ -8,8 +8,7 @@ function peco_select_ghq_repository
   ghq list | peco $peco_flags | read line
 
   if [ $line ]
-    ghq root | read dir
-    cd $dir/$line
+    ghq look $line
     commandline -f repaint
   end
 end


### PR DESCRIPTION
Thank you for your great fish function!

Your function make me so comfortable to manage repositories. But, I have an issue, that it does not support for multiple ghq roots.  
I have two ghq roots, `~/src` for `ghq get` and `~/go/src` for `go get`. When I invoke this function to open second ghq root, `~/go/src`, I met a following Error.

```
cd: The directory '~/src/**' does not exist
```

So I modified the directory change command from `cd $dir/$line` to `ghq look`. It works well in my environment.  
I'm very glad if you gave me some feedback or merged this PR.