### PR TITLE
Bind command for interactive program

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ If you'd like to bind CTRL+]
 
 ```
 function fish_user_key_bindings
-  bind \c] peco_select_ghq_repository
+  bind \c] 'stty sane; peco_select_ghq_repository'
 end
 ```


### PR DESCRIPTION
Interactive program doesn't work when moving repository via key bindings.
It can avoid  by adding `stty sane;` 

from https://github.com/fish-shell/fish-shell/issues/4772